### PR TITLE
Traditional Chinese translation

### DIFF
--- a/app/src/main/res/values-v29/strings.xml
+++ b/app/src/main/res/values-v29/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="permission_storage_hint">Storage permission(read only, legacy mode only) is required to fetch your .lrc files.</string>
+    <string name="permission_storage_hint">Storage permission (read only, legacy mode only) is required to fetch your .lrc files.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -13,7 +13,7 @@
     <string name="permission_floating_denied">绘制权限被拒绝</string>
     <string name="permission_floating_check">检查显示权限</string>
     <string name="done_hint">准备好了！ 打开 Poweramp，开始播放，点击通知，享受吧！</string>
-    <string name="done_extra">注意： 若歌词延迟，请尝试暂停并恢复播放。此外， Poweramp 导致的延迟也可能是原因，并且 Poweramp 仅汇报以秒为单位的位置，从而当歌词过快或从一秒的中间开始（比如 00:01.50）则会不可避免地出现延迟。如果您认为所碰到的确实是 bug ，请在 GitHub 开一个附带了重现步骤及 Poweramp 延迟的 issue 。</string>
+    <string name="done_extra">注意：\n若歌词延迟，请尝试暂停并恢复播放。此外， Poweramp 导致的延迟也可能是原因，并且 Poweramp 仅汇报以秒为单位的位置，从而当歌词过快或从一秒的中间开始（比如 00:01.50）则会不可避免地出现延迟。如果您认为所碰到的确实是 bug ，请在 GitHub 开一个附带了重现步骤及 Poweramp 延迟的 issue 。</string>
 
     <string name="notification_entrance_channel_name">入口</string>
     <string name="notification_message_hide">点击隐藏</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -13,7 +13,7 @@
     <string name="permission_floating_denied">绘制权限被拒绝</string>
     <string name="permission_floating_check">检查显示权限</string>
     <string name="done_hint">准备好了！ 打开 Poweramp，开始播放，点击通知，享受吧！</string>
-    <string name="done_extra">注意：\n若歌词延迟，请尝试暂停并恢复播放。此外， Poweramp 导致的延迟也可能是原因，并且 Poweramp 仅汇报以秒为单位的位置，从而当歌词过快或从一秒的中间开始（比如 00:01.50）则会不可避免地出现延迟。如果您认为所碰到的确实是 bug ，请在 GitHub 开一个附带了重现步骤及 Poweramp 延迟的 issue 。</string>
+    <string name="done_extra">注意： 若歌词延迟，请尝试暂停并恢复播放。此外， Poweramp 导致的延迟也可能是原因，并且 Poweramp 仅汇报以秒为单位的位置，从而当歌词过快或从一秒的中间开始（比如 00:01.50）则会不可避免地出现延迟。如果您认为所碰到的确实是 bug ，请在 GitHub 开一个附带了重现步骤及 Poweramp 延迟的 issue 。</string>
 
     <string name="notification_entrance_channel_name">入口</string>
     <string name="notification_message_hide">点击隐藏</string>

--- a/app/src/main/res/values-zh-rTW-v29/strings.xml
+++ b/app/src/main/res/values-zh-rTW-v29/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="permission_storage_hint">要獲取 .lrc 檔案，需要儲存權限（只讀，古董模式限定）。</string>
+
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Poweramp 歌詞外掛</string>
+    <string name="main_message">這是一個用以彌補 Poweramp 本地歌詞功能缺乏的簡單應用程式。開始之前，我們需要一些權限，來使它正常工作。\n若所有權限都已正確獲取，則將進入配置頁面。</string>
+    <string name="main_old">您的 Android 版本無需手動獲取任何權限，所以接下來什麼都不用做。</string>
+    <string name="main_configuration">權限就緒，馬上進入設定頁！</string>
+    <string name="permission_storage_hint">要獲取 .lrc 檔案，需要儲存權限（只讀）。</string>
+    <string name="permission_storage_granted">已獲取儲存權限</string>
+    <string name="permission_storage_denied">儲存權限被拒絕</string>
+    <string name="permission_storage_check">檢查儲存權限</string>
+    <string name="permission_floating_hint">要顯示歌詞浮動視窗，需要繪製權限。</string>
+    <string name="permission_floating_granted">已獲取繪製權限</string>
+    <string name="permission_floating_denied">繪製權限被拒絕</string>
+    <string name="permission_floating_check">檢查顯示權限</string>
+    <string name="done_hint">準備好了！開啟 Poweramp，開始播放，點選通知，享受吧！</string>
+    <string name="done_extra">注意： 若歌詞延遲，請嘗試暫停並恢復播放。此外， Poweramp 導致的延遲也可能是原因。因 Poweramp 僅彙報以秒為單位的位置，從而當歌詞過快或從一秒的中間開始（比如 00:01.50）則會不可避免地出現延遲。如果您認為所碰到的確實是 bug，請在 GitHub 開一個附帶了重現步驟及 Poweramp 延遲的 issue。</string>
+
+    <string name="notification_entrance_channel_name">入口</string>
+    <string name="notification_message_hide">點選隱藏</string>
+    <string name="notification_message_show">點選顯示</string>
+    <string name="notification_path_channel_name">路徑設定</string>
+    <string name="notification_path_title">需要權限</string>
+    <string name="notification_path_message">請指定資料夾給\u0020</string>
+    <string name="notification_placeholder_channel_name">佔位符</string>
+    <string name="notification_placeholder_message">正在後臺執行（可禁用該通知）。</string>
+
+    <string name="no_lrc_hint">歌詞不見了</string>
+
+    <string name="preference_ui">UI</string>
+    <string name="preference_ui_duration">動畫時長</string>
+    <string name="preference_ui_duration_description">預設 250 毫秒，目前\u0020</string>
+    <string name="preference_ui_height">視窗高度</string>
+    <string name="preference_ui_height_description">預設 36 dp，目前\u0020</string>
+    <string name="preference_ui_text">歌詞顏色</string>
+    <string name="preference_experimental">實驗性功能</string>
+    <string name="preference_experimental_legacy">使用舊檔案訪問方式</string>
+    <string name="preference_experimental_legacy_description">（僅 Android 10）可能在正常模式不工作時有用，但若如此也請報告問題</string>
+    <string name="preference_experimental_encoding">使用 GB18030 編碼</string>
+    <string name="preference_experimental_encoding_description">大概能解決 QQ 音樂自動下載的歌詞全是亂碼的問題</string>
+    <string name="preference_experimental_report">報告問題</string>
+    <string name="preference_experimental_report_description">產生一個包含了所有可能出問題的東西的日誌（不會包含個人資訊）</string>
+    <string name="preference_after_restart">將在應用程式重新啓動後生效。</string>
+    <string name="preference_after_reload">將在歌詞重新載入後生效。</string>
+    <string name="preference_default">預設</string>
+    <string name="error">發生了一點問題</string>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,7 +7,7 @@
     <color name="lrc_current_purple">#A851F0</color>
     <color name="lrc_normal">#BDBDBD</color>
 
-    <color name="text_success">#0D0</color>
-    <color name="text_failure">#D00</color>
+    <color name="text_success">#00C851</color>
+    <color name="text_failure">#ff4444</color>
     <color name="text_normal">#222</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Poweramp LRC Plugin</string>
-    <string name="main_message">This is a simple app to fix Poweramp\'s lack of local LRC lyrics support. Before we start, some permissions are required to work correctly. After permissions are granted, a configuration page will appear.</string>
+    <string name="main_message">This is a simple app to fix Poweramp\'s lack of local LRC lyrics support. Before we start, some permissions are required to work correctly. \nAfter permissions are granted, a configuration page will appear.</string>
     <string name="main_old">Your Android version does not require any permission to be requested.</string>
     <string name="main_configuration">All permissions are ready, click next to make customizations!</string>
     <string name="permission_storage_hint">Storage permission(read only) is required to fetch your .lrc files.</string>
@@ -12,7 +12,7 @@
     <string name="permission_floating_denied">Drawing permission denied.</string>
     <string name="permission_floating_check">Check display permission</string>
     <string name="done_hint">All ready! Open Poweramp, start playing, click the notification and enjoy!</string>
-    <string name="done_extra">Note: When lyrics delay, try pausing and resuming playing. Delay caused by Poweramp may also be the cause, as Poweramp reports position in seconds, thus when the lyrics change too often or are at the middle of a second there will unavoidably exist delay. If you believe what you meet is a bug, please open a issue attached with procedures to reproduce the bug and delay caused by Poweramp on GitHub.</string>
+    <string name="done_extra">Note: \nWhen lyrics delay, try pausing and resuming playing. Delay caused by Poweramp may also be the cause, as Poweramp reports position in seconds, thus when the lyrics change too often or are at the middle of a second there will unavoidably exist delay. If you believe what you meet is a bug, please open a issue attached with procedures to reproduce the bug and delay caused by Poweramp on GitHub.</string>
 
     <string name="notification_entrance_channel_name">Entrance</string>
     <string name="notification_message_hide">Click to hide</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Poweramp LRC Plugin</string>
-    <string name="main_message">This is a simple app to make up for Poweramp\'s lack of local lyrics parser function. Before we start, some permissions are required to guarantee it works correctly. \nAlso, if all permissions are granted properly, next time a configuration page will be loaded.</string>
-    <string name="main_old">Your Android version does not require any permission to be requested by the app, so nothing will get changed.</string>
+    <string name="main_message">This is a simple app to fix Poweramp\'s lack of local LRC lyrics support. Before we start, some permissions are required to work correctly. After permissions are granted, a configuration page will appear.</string>
+    <string name="main_old">Your Android version does not require any permission to be requested.</string>
     <string name="main_configuration">All permissions are ready, click next to make customizations!</string>
     <string name="permission_storage_hint">Storage permission(read only) is required to fetch your .lrc files.</string>
     <string name="permission_storage_granted">Storage permission granted.</string>
@@ -12,25 +12,25 @@
     <string name="permission_floating_denied">Drawing permission denied.</string>
     <string name="permission_floating_check">Check display permission</string>
     <string name="done_hint">All ready! Open Poweramp, start playing, click the notification and enjoy!</string>
-    <string name="done_extra">Note:\nWhen lyrics delay, try pausing and resuming playing. By the way, delay caused by Poweramp may also be the cause, and Poweramp only reports position metered in second, thus when the lyrics go too fast or are at near the middle of a second (e.g. a lyric starting from 00:01.50) there will unavoidably exist delay. If you believe what you meet is a bug, please open a issue attached with procedures to reproduce the bug and delay caused by Poweramp on GitHub.</string>
+    <string name="done_extra">Note: When lyrics delay, try pausing and resuming playing. Delay caused by Poweramp may also be the cause, as Poweramp reports position in seconds, thus when the lyrics change too often or are at the middle of a second there will unavoidably exist delay. If you believe what you meet is a bug, please open a issue attached with procedures to reproduce the bug and delay caused by Poweramp on GitHub.</string>
 
     <string name="notification_entrance_channel_name">Entrance</string>
     <string name="notification_message_hide">Click to hide</string>
     <string name="notification_message_show">Click to show</string>
     <string name="notification_path_channel_name">Path setting</string>
     <string name="notification_path_title">Permission needed</string>
-    <string name="notification_path_message">Please specify a folder for\u0020</string>
+    <string name="notification_path_message">Please specify a folder for \\u0020</string>
     <string name="notification_placeholder_channel_name">Placeholder</string>
     <string name="notification_placeholder_message">Running in the background (this notification can be disabled).</string>
 
-    <string name="no_lrc_hint">WANTED: Lyrics</string>
+    <string name="no_lrc_hint">Lyrics not found</string>
 
     <string name="preference_ui">UI</string>
     <string name="preference_ui_duration">Animation duration</string>
     <string name="preference_ui_duration_description">Default is 250 ms, current:\u0020</string>
     <string name="preference_ui_height">Window height</string>
     <string name="preference_ui_height_description">Default is 36 dp, current:\u0020</string>
-    <string name="preference_ui_text">Lyric color</string>
+    <string name="preference_ui_text">Lyrics color</string>
     <string name="preference_experimental">Experimental features</string>
     <string name="preference_experimental_legacy">File access in legacy mode</string>
     <string name="preference_experimental_legacy_description">(Android 10 only) May be useful if normal version is not working, but please also report when that happens</string>


### PR DESCRIPTION
I added Traditional Chinese translation, fixed some English translation issues, and changed the color of error/success to a slightly less bright color. I did not change the Simplified Chinese translation accordingly as I'm not sure about the language usage of Simplified Chinese

Thank you for the app! I might work on lyrics window style later to implement the font color and window size options